### PR TITLE
29 - Critical Bug Fixes

### DIFF
--- a/src/components/HotkeySection.tsx
+++ b/src/components/HotkeySection.tsx
@@ -3,6 +3,7 @@ import { loadHotkeysConfig, saveHotkeysConfig } from "../utilities/configUtility
 import { validHotkeys } from "../data/validHotkeys";
 import { splitActions } from "../utilities/actionsManipulations";
 import { defaultDisabledActions } from "../data/hotkeySections";
+import { HotkeyEntry } from "../types";
 
 interface HotkeySectionProps {
   title: string;
@@ -164,13 +165,6 @@ export const HotkeySection: React.FC<HotkeySectionProps> = ({ title, actions, no
     console.log('selected hotkeys changed', selectedHotkeys)
   }, [selectedHotkeys])
 
-
-  type HotkeyEntry = {
-    action: string | string[];
-    hotkey: string;
-    disabled: boolean;
-  };
-
   function checkIfDisabled(action: string) {
     const actionParts = splitActions(action);
     return actionParts.some(part => disabledActions.includes(part));
@@ -179,14 +173,13 @@ export const HotkeySection: React.FC<HotkeySectionProps> = ({ title, actions, no
 
   function findHotkeyByAction(action: string, hotkeysConfig: HotkeyEntry[]): string {
     for (const hotkeyItem of hotkeysConfig) {
-      const actions = hotkeyItem.action;
-      if (actions === action) {
+      const actionName = hotkeyItem.action;
+      if (actionName === action) {
         return hotkeyItem.hotkey;
       } else if (action.includes('/')) {
+        // Handle actions like "To Extra Deck/To Extra Deck FU" by checking if any part matches
         const actionParts = splitActions(action);
-        if (typeof actions === 'string' && actionParts.includes(actions)) {
-          return hotkeyItem.hotkey;
-        } else if (Array.isArray(actions) && actionParts.some(part => actions.includes(part))) {
+        if (actionParts.includes(actionName)) {
           return hotkeyItem.hotkey;
         }
       }

--- a/src/content_script.tsx
+++ b/src/content_script.tsx
@@ -200,8 +200,6 @@ window.onload = async function() {
     }
   });
 
-  chrome.storage.onChanged.addListener(handleOptionsChange);
-
   const chatInput = document.querySelectorAll('input.cin_txt')[1] as HTMLInputElement;
   let chatInputFocused = false;
   let LPInputFocused = false;

--- a/src/types/hotkeys.ts
+++ b/src/types/hotkeys.ts
@@ -1,0 +1,13 @@
+/**
+ * Represents a single hotkey configuration entry.
+ * 
+ * @property action - The action name that the hotkey triggers (e.g., "View Graveyard", "To Hand")
+ * @property hotkey - The keyboard key that triggers this action (e.g., "g", "escape")
+ * @property disabled - Whether this hotkey is currently disabled
+ */
+export interface HotkeyEntry {
+  action: string;
+  hotkey: string;
+  disabled: boolean;
+}
+

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from './hotkeys';

--- a/src/utilities/configUtility.ts
+++ b/src/utilities/configUtility.ts
@@ -1,8 +1,4 @@
-export interface HotkeyEntry {
-  action: string;
-  hotkey: string;
-  disabled: boolean;
-}
+import { HotkeyEntry } from '../types';
 
 export async function loadHotkeysConfig(): Promise<HotkeyEntry[]> {
   return new Promise<HotkeyEntry[]>((resolve) => {


### PR DESCRIPTION
fix: remove duplicate storage listener and consolidate HotkeyEntry types

- Remove duplicate chrome.storage.onChanged listener in content_script.tsx
- Create centralized HotkeyEntry type in src/types/hotkeys.ts
- Remove duplicate HotkeyEntry interface from configUtility.ts
- Remove inconsistent HotkeyEntry type from HotkeySection.tsx (was incorrectly allowing action: string | string[])
- Fix findHotkeyByAction function to correctly handle action as string type
- Add barrel export pattern with src/types/index.ts for cleaner imports
- Update all imports to use centralized types from src/types